### PR TITLE
Add support for TCP communication

### DIFF
--- a/rtlsdr/__init__.py
+++ b/rtlsdr/__init__.py
@@ -19,7 +19,10 @@ try:                from  librtlsdr import librtlsdr
 except ImportError: from .librtlsdr import librtlsdr
 try:                from  rtlsdr import RtlSdr
 except ImportError: from .rtlsdr import RtlSdr
+try:                from rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
+except ImportError: from .rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
 try:                from  helpers import limit_calls, limit_time
 except ImportError: from .helpers import limit_calls, limit_time
 
-__all__  = ['librtlsdr', 'RtlSdr', 'limit_calls', 'limit_time']
+__all__  = ['librtlsdr', 'RtlSdr', 'RtlSdrTcpServer', 'RtlSdrTcpClient',
+            'limit_calls', 'limit_time']

--- a/rtlsdr/helpers.py
+++ b/rtlsdr/helpers.py
@@ -18,12 +18,6 @@
 from __future__ import division, print_function
 from functools import wraps
 import time
-import base64
-import json
-try:
-    import numpy as np
-except ImportError:
-    np = None
 
 def limit_time(max_seconds):
     '''Decorator to cancel async reads after "max_seconds" seconds elapse.
@@ -78,60 +72,6 @@ def limit_calls(max_calls):
 def test_callback(buffer, rtlsdr_obj):
     print('In callback')
     print('   signal mean:', sum(buffer)/len(buffer))
-
-## From http://stackoverflow.com/questions/27909658/
-
-
-class NumpyEncoder(json.JSONEncoder):
-    """JSONEncoder subclass to support serialization of numpy arrays.
-    Also handles complex numbers.
-    """
-    def default(self, obj):
-        if np is None:
-            if isinstance(obj, complex):
-                return dict(__complex__=[obj.real, obj.imag])
-        elif isinstance(obj, np.ndarray):
-            data_b64 = base64.b64encode(obj.dumps())
-            return dict(__ndarray__=data_b64)
-        return json.JSONEncoder.default(self, obj)
-
-
-def json_numpy_obj_hook(dct):
-    """Hook to deserialize numpy arrays and complex numbers formatted
-    by NumpyEncoder.
-    """
-    if isinstance(dct, dict):
-        if '__ndarray__' in dct:
-            data = base64.b64decode(dct['__ndarray__'])
-            return np.loads(data)
-        elif '__complex__' in dct:
-            data = dct['__complex__']
-            return complex(*data)
-    return dct
-
-
-class NumpyJson(object):
-    """Convenience class to emulate the builtin json module adding
-    a JSONEncoder and object hook to support numpy arrays and complex numbers.
-    """
-    def dumps(self, *args, **kwargs):
-        kwargs.setdefault('cls', NumpyEncoder)
-        return json.dumps(*args, **kwargs)
-
-    def loads(self, *args, **kwargs):
-        kwargs.setdefault('object_hook', json_numpy_obj_hook)
-        return json.loads(*args, **kwargs)
-
-    def dump(self, *args, **kwargs):
-        kwargs.setdefault('cls', NumpyEncoder)
-        return json.dump(*args, **kwargs)
-
-    def load(self, *args, **kwargs):
-        kwargs.setdefault('object_hook', json_numpy_obj_hook)
-        return json.load(*args, **kwargs)
-
-numpyjson = NumpyJson()
-##
 
 
 def main():

--- a/rtlsdr/helpers.py
+++ b/rtlsdr/helpers.py
@@ -96,19 +96,23 @@ def json_numpy_obj_hook(dct):
 
 class NumpyJson(object):
     def dumps(self, *args, **kwargs):
-        kwargs.setdefault('cls', NumpyEncoder)
+        if np is not None:
+            kwargs.setdefault('cls', NumpyEncoder)
         return json.dumps(*args, **kwargs)
 
     def loads(self, *args, **kwargs):
-        kwargs.setdefault('object_hook', json_numpy_obj_hook)
+        if np is not None:
+            kwargs.setdefault('object_hook', json_numpy_obj_hook)
         return json.loads(*args, **kwargs)
 
     def dump(self, *args, **kwargs):
-        kwargs.setdefault('cls', NumpyEncoder)
+        if np is not None:
+            kwargs.setdefault('cls', NumpyEncoder)
         return json.dump(*args, **kwargs)
 
     def load(self, *args, **kwargs):
-        kwargs.setdefault('object_hook', json_numpy_obj_hook)
+        if np is not None:
+            kwargs.setdefault('object_hook', json_numpy_obj_hook)
         return json.load(*args, **kwargs)
 
 numpyjson = NumpyJson()

--- a/rtlsdr/helpers.py
+++ b/rtlsdr/helpers.py
@@ -81,7 +81,11 @@ def test_callback(buffer, rtlsdr_obj):
 
 ## From http://stackoverflow.com/questions/27909658/
 
+
 class NumpyEncoder(json.JSONEncoder):
+    """JSONEncoder subclass to support serialization of numpy arrays.
+    Also handles complex numbers.
+    """
     def default(self, obj):
         if np is None:
             if isinstance(obj, complex):
@@ -91,7 +95,11 @@ class NumpyEncoder(json.JSONEncoder):
             return dict(__ndarray__=data_b64)
         return json.JSONEncoder.default(self, obj)
 
+
 def json_numpy_obj_hook(dct):
+    """Hook to deserialize numpy arrays and complex numbers formatted
+    by NumpyEncoder.
+    """
     if isinstance(dct, dict):
         if '__ndarray__' in dct:
             data = base64.b64decode(dct['__ndarray__'])
@@ -101,7 +109,11 @@ def json_numpy_obj_hook(dct):
             return complex(*data)
     return dct
 
+
 class NumpyJson(object):
+    """Convenience class to emulate the builtin json module adding
+    a JSONEncoder and object hook to support numpy arrays and complex numbers.
+    """
     def dumps(self, *args, **kwargs):
         kwargs.setdefault('cls', NumpyEncoder)
         return json.dumps(*args, **kwargs)
@@ -120,6 +132,7 @@ class NumpyJson(object):
 
 numpyjson = NumpyJson()
 ##
+
 
 def main():
     from rtlsdr import RtlSdr

--- a/rtlsdr/rtlsdr.py
+++ b/rtlsdr/rtlsdr.py
@@ -46,6 +46,9 @@ class BaseRtlSdr(object):
     device_opened = False
 
     def __init__(self, device_index=0, test_mode_enabled=False):
+        self.open(device_index, test_mode_enabled)
+
+    def open(self, device_index=0, test_mode_enabled=False):
         ''' Initialize RtlSdr object.
         The test_mode_enabled parameter can be used to enable a special test mode, which will return the value of an
         internal RTL2832 8-bit counter with calls to read_bytes()
@@ -73,10 +76,12 @@ class BaseRtlSdr(object):
             raise IOError('Error code %d when resetting buffer (device index = %d)'\
                           % (result, device_index))
 
+        self.device_opened = True
+        self.init_device_values()
+
+    def init_device_values(self):
         self.gain_values = self.get_gains()
         self.valid_gains_db = [val/10 for val in self.gain_values]
-
-        self.device_opened = True
 
         # set default state
         self.set_sample_rate(self.DEFAULT_RS)

--- a/rtlsdr/rtlsdr.py
+++ b/rtlsdr/rtlsdr.py
@@ -354,7 +354,7 @@ class BaseRtlSdr(object):
 
 # This adds async read support to base class BaseRtlSdr (don't use that one)
 class RtlSdr(BaseRtlSdr):
-    DEFAULT_ASYNC_BUF_NUMBER = 32
+    DEFAULT_ASYNC_BUF_NUMBER = 0 # librtlsdr will use the default (15)
     DEFAULT_READ_SIZE = 1024
 
     read_async_canceling = False

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -26,15 +26,18 @@ except ImportError:
 
 MAX_BUFFER_SIZE = 4096
 
+
 class CommunicationError(Exception):
     def __init__(self, msg, source_exc=None):
         self.msg = msg
         self.source_exc = source_exc
+
     def __str__(self):
         s = self.msg
         if self.source_exc is not None:
             s = 'SOURCE EXCEPTION:\n%s\n\n%s' % (traceback.format_exc(), s)
         return s
+
 
 class RtlSdrTcpBase(RtlSdr):
     # Use port 1235 as default since rtl_tcp uses 1234
@@ -52,18 +55,23 @@ class RtlSdrTcpBase(RtlSdr):
         self.server_thread = None
         super(RtlSdrTcpBase, self).__init__(device_index, test_mode_enabled)
 
+
 class RtlSdrTcpServer(RtlSdrTcpBase):
-    '''Server that connects to a physical dongle to allow client connections
-    '''
+
+    """Server that connects to a physical dongle to allow client connections.
+    """
+
     def open(self, device_index=0, test_mode_enabled=False):
         if not self.device_ready:
             return
         super(RtlSdrTcpServer, self).open(device_index, test_mode_enabled)
+
     def run(self):
-        '''Runs the server thread and returns.  Use this only if you are
+        """Runs the server thread and returns.  Use this only if you are
         running mainline code afterwards.
         The server must explicitly be stopped by the stop method before exit.
-        '''
+
+        """
         if self.server_thread is None:
             self.server_thread = ServerThread(self)
         if self.server_thread.running.is_set():
@@ -73,10 +81,11 @@ class RtlSdrTcpServer(RtlSdrTcpBase):
         if self.server_thread.stopped.is_set():
             self.server_thread = None
             self.close()
+
     def run_forever(self):
-        '''Runs the server and begins a mainloop.
+        """Runs the server and begins a mainloop.
         The loop will exit with Ctrl-C.
-        '''
+        """
         self.run()
         while True:
             try:
@@ -84,15 +93,17 @@ class RtlSdrTcpServer(RtlSdrTcpBase):
             except KeyboardInterrupt:
                 self.close()
                 break
+
     def close(self):
-        '''Stops the server (if it's running) and closes the connection to the
+        """Stops the server (if it's running) and closes the connection to the
         dongle.
-        '''
+        """
         if self.server_thread is not None:
             if self.server_thread.running.is_set():
                 self.server_thread.stop()
             self.server_thread = None
         super(RtlSdrTcpServer, self).close()
+
 
 class ServerThread(threading.Thread):
     def __init__(self, rtl_sdr):
@@ -100,6 +111,7 @@ class ServerThread(threading.Thread):
         self.rtl_sdr = rtl_sdr
         self.running = threading.Event()
         self.stopped = threading.Event()
+
     def run(self):
         try:
             self.server = Server(self.rtl_sdr)
@@ -116,24 +128,26 @@ class ServerThread(threading.Thread):
         self.running.clear()
         rtl_sdr.device_ready = False
         self.stopped.set()
+
     def stop(self):
         self.server.shutdown()
         self.server.server_close()
         self.stopped.wait()
 
+
 class Server(TCPServer):
     REQUEST_RECV_SIZE = 1024
+
     def __init__(self, rtl_sdr):
         self.rtl_sdr = rtl_sdr
         server_addr = (rtl_sdr.hostname, rtl_sdr.port)
         TCPServer.__init__(self, server_addr, RequestHandler)
         self.handlers = set()
+
     def server_close(self):
         for h in self.handlers:
             h.close()
-    #def finish_request(self, request, client_address):
-    #    handler = TcpServer.finish_request(self, request, client_address)
-    #    self.handlers.add(handler)
+
 
 API_METHODS = (
     'get_center_freq', 'set_center_freq',
@@ -152,43 +166,48 @@ API_DESCRIPTORS = {
     'freq_correction',
 }
 
+
 class MessageBase(object):
-    '''Base class for messages sent between clients and servers.
+
+    """Base class for messages sent between clients and servers.
+
     Hanldes serialization/deserialization and communication with
     socket type objects.
-    '''
+
+    """
+
     def __init__(self, **kwargs):
         self.data_len = None
         self.timestamp = kwargs.get('timestamp')
         self.header = self.get_header(**kwargs)
         self.data = self.get_data(**kwargs)
         self.data_is_complex = False
+
     @staticmethod
     def _send(sock, data):
         r, w, e = select.select([], [sock], [], .5)
         if sock not in w:
             raise CommunicationError('socket %r not ready for write' % (sock))
         return sock.send(data)
+
     @staticmethod
     def _recv(sock):
         r, w, e = select.select([sock], [], [])
         if sock not in r:
             raise CommunicationError('socket %r not ready for read' % (sock))
         return sock.recv(MAX_BUFFER_SIZE)
+
     @classmethod
     def from_remote(cls, sock):
-        '''Reads data for the socket buffer and reconstructs the appropriate
+        """Reads data for the socket buffer and reconstructs the appropriate
         message that was sent by the other end.
-        '''
+        """
         header = cls._recv(sock)
-        try:
-            kwargs = numpyjson.loads(header)
-        except ValueError:
-            #print(header)
-            raise
+        kwargs = numpyjson.loads(header)
         if kwargs.get('ACK'):
             cls = AckMessage
         return cls(**kwargs)
+
     def get_header(self, **kwargs):
         d = {}
         ts = kwargs.get('timestamp')
@@ -196,16 +215,21 @@ class MessageBase(object):
             ts = time.time()
         d['timestamp'] = ts
         return d
+
     def get_data(self, **kwargs):
         return kwargs.get('data')
+
     def send_message(self, sock):
         header, data = self._serialize()
         self._send(sock, header)
+
     def get_response(self, sock):
         cls = self.get_response_class()
         return cls.from_remote(sock)
+
     def get_ack_response(self, sock):
         return AckMessage.from_remote(sock)
+
     def _serialize(self):
         if not self.data_is_complex:
             d = self.header.copy()
@@ -216,20 +240,26 @@ class MessageBase(object):
             self.data_len = len(data)
         header = self._serialize_header()
         return header, data
+
     def _serialize_header(self):
         header = self.header
         header['data_len'] = self.data_len
         return numpyjson.dumps(self.header)
+
     def _serialize_data(self):
         return numpyjson.dumps(self.data)
 
+
 class AckMessage(MessageBase):
-    '''Simple message type meant for ACKnolegemnt of message receipt.'''
+
+    """Simple message type meant for ACKnolegemnt of message receipt."""
+
     def get_header(self, **kwargs):
         d = super(AckMessage, self).get_header(**kwargs)
         d['ACK'] = True
         d['ok'] = kwargs.get('ok', True)
         return d
+
 
 class ServerMessage(MessageBase):
     def __init__(self, **kwargs):
@@ -242,21 +272,19 @@ class ServerMessage(MessageBase):
                 if isinstance(self.data[0], complex):
                     is_complex = True
         self.data_is_complex = is_complex
+
     @classmethod
     def from_remote(cls, sock):
-        '''Reads data for the socket buffer and reconstructs the appropriate
+        """Reads data for the socket buffer and reconstructs the appropriate
         message that was sent by the other end.
 
         This method is used by clients to reconstruct ServerMessage objects
         and if necessary, use multiple read calls to get the entire message
         (if the message size is greater than the buffer length)
-        '''
+
+        """
         header = cls._recv(sock)
-        try:
-            kwargs = numpyjson.loads(header)
-        except ValueError:
-            #print(header)
-            raise
+        kwargs = numpyjson.loads(header)
         data_len = kwargs.get('data_len')
         data = kwargs.get('data')
         if data_len is None or data is not None:
@@ -273,15 +301,18 @@ class ServerMessage(MessageBase):
             data_len -= len(_recv)
         kwargs['data'] = numpyjson.loads(recv)
         return cls(**kwargs)
+
     def send_message(self, sock):
-        '''Sends the message data to clients.
+        """Sends the message data to clients.
+
         If necessary, uses multiple calls to send to ensure all data has
         actually been sent through the socket objects's buffer.
-        '''
+
+        """
         header, data = self._serialize()
 
         self._send(sock, header)
-        if data is not None and self.header.get('name') != 'read_samples_async':
+        if data is not None:
             ack = self.get_ack_response(sock)
             if not ack.header.get('ok'):
                 raise CommunicationError('No ACK received')
@@ -290,6 +321,7 @@ class ServerMessage(MessageBase):
                 sent = self._send(sock, data)
                 data_len -= sent
                 data = data[sent:]
+
     def get_header(self, **kwargs):
         d = super(ServerMessage, self).get_header(**kwargs)
         d['success'] = kwargs.get('success', True)
@@ -299,25 +331,31 @@ class ServerMessage(MessageBase):
         else:
             d['request'] = kwargs.get('request')
         return d
+
     def get_response_class(self):
         return AckMessage
+
 
 class ClientMessage(MessageBase):
     def send_message(self, sock):
         super(ClientMessage, self).send_message(sock)
         return self.get_response(sock)
+
     def get_header(self, **kwargs):
         d = super(ClientMessage, self).get_header(**kwargs)
         keys = ['type', 'name']
         d.update({k: kwargs.get(k) for k in keys})
         return d
+
     def get_response_class(self):
         return ServerMessage
+
 
 class RequestHandler(BaseRequestHandler):
     def setup(self):
         self.finished = False
         self.server.handlers.add(self)
+
     def handle(self, rx_message=None):
         if rx_message is None:
             rx_message = ClientMessage.from_remote(self.request)
@@ -333,10 +371,13 @@ class RequestHandler(BaseRequestHandler):
         if r is False:
             nak = AckMessage(ok=False)
             nak.send_message(self.request)
+
     def finish(self):
         self.server.handlers.discard(self)
+
     def close(self):
         self.finished = True
+
     def handle_method_call(self, rx_message):
         rtl_sdr = self.server.rtl_sdr
         method_name = rx_message.header.get('name')
@@ -346,13 +387,15 @@ class RequestHandler(BaseRequestHandler):
         try:
             m = getattr(rtl_sdr, method_name)
         except AttributeError:
-            raise CommunicationError('sdr has no attribute "%s"' % (method_name))
+            msg = 'sdr has no attribute "%s"' % (method_name)
+            raise CommunicationError(msg)
         if arg is not None:
             resp = m(arg)
         else:
             resp = m()
         tx_message = ServerMessage(client_message=rx_message, data=resp)
         tx_message.send_message(self.request)
+
     def handle_prop_set(self, rx_message):
         rtl_sdr = self.server.rtl_sdr
         prop_name = rx_message.header.get('name')
@@ -362,6 +405,7 @@ class RequestHandler(BaseRequestHandler):
         setattr(rtl_sdr, prop_name, value)
         tx_message = ServerMessage(client_message=rx_message)
         tx_message.send_message(self.request)
+
     def handle_prop_get(self, rx_message):
         prop_name = rx_message.header.get('name')
         if prop_name not in API_DESCRIPTORS:
@@ -371,24 +415,33 @@ class RequestHandler(BaseRequestHandler):
         tx_message = ServerMessage(client_message=rx_message, data=value)
         tx_message.send_message(self.request)
 
+
 class RtlSdrTcpClient(RtlSdrTcpBase):
-    '''Client object that connects to a remote server.
+
+    """Client object that connects to a remote server.
+
     Exposes most of the methods and descriptors that are available in the
     RtlSdr class in a transparent manner allowing an interface that is nearly
     identical to the core API.
-    '''
+
+    """
+
     def open(self, *args):
         self._socket = None
         self._keep_alive = False
         self.device_opened = True
+
     def close(self):
         self.device_opened = False
+
     def _build_socket(self):
         s = getattr(self, '_socket', None)
         if s is None:
-            s = self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s = self._socket = socket.socket(socket.AF_INET,
+                                             socket.SOCK_STREAM)
             s.connect((self.hostname, self.port))
         return s
+
     def _close_socket(self):
         if self._keep_alive:
             return
@@ -398,12 +451,14 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
         print 'client closing socket'
         s.close()
         self._socket = None
+
     def _communicate(self, tx_message):
         s = self._build_socket()
         resp = tx_message.send_message(s)
         if isinstance(resp, ServerMessage):
             if not resp.header.get('success'):
-                raise CommunicationError('server was unsuccessful. msg=%s' % (tx_message.header))
+                msg = 'server was unsuccessful. msg=%s' % (tx_message.header)
+                raise CommunicationError(msg)
             resp_data = resp.data
         elif isinstance(resp, AckMessage):
             if not resp.header.get('ok'):
@@ -411,37 +466,52 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
             resp_data = None
         self._close_socket()
         return resp_data
+
     def _communicate_method(self, method_name, arg=None):
         msg = ClientMessage(type='method', name=method_name, data=arg)
         return self._communicate(msg)
+
     def _communicate_descriptor_get(self, prop_name):
         msg = ClientMessage(type='prop_get', name=prop_name)
         return self._communicate(msg)
+
     def _communicate_descriptor_set(self, prop_name, value):
         msg = ClientMessage(type='prop_set', name=prop_name, data=value)
         return self._communicate(msg)
+
     def get_center_freq(self):
         return self._communicate_descriptor_get('fc')
+
     def set_center_freq(self, value):
         self._communicate_descriptor_set('fc', value)
+
     def get_sample_rate(self):
         return self._communicate_descriptor_get('rs')
+
     def set_sample_rate(self, value):
         self._communicate_descriptor_set('rs', value)
+
     def get_gain(self):
         return self._communicate_descriptor_get('gain')
+
     def set_gain(self, value):
         self._communicate_descriptor_set('gain', value)
+
     def get_freq_correction(self):
         return self._communicate_descriptor_get('freq_correction')
+
     def set_freq_correction(self, value):
         self._communicate_descriptor_set('freq_correction', value)
+
     def get_gains(self):
         return self._communicate_method('get_gains')
+
     def get_tuner_type(self):
         return self._communicate_method('get_tuner_type')
+
     def set_direct_sampling(self, value):
         self._communicate_method('set_direct_sampling', value)
+
     def read_samples(self, num_samples=RtlSdr.DEFAULT_READ_SIZE):
         return self._communicate_method('read_samples', num_samples)
     center_freq = fc = property(get_center_freq, set_center_freq)
@@ -449,10 +519,11 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
     gain = property(get_gain, set_gain)
     freq_correction = property(get_freq_correction, set_freq_correction)
 
+
 def run_server():
-    '''Convenience function to run the server from the command line
+    """Convenience function to run the server from the command line
     with options for hostname, port and device index.
-    '''
+    """
     p = argparse.ArgumentParser()
     p.add_argument(
         '-a', '--address',
@@ -475,6 +546,7 @@ def run_server():
     o = vars(args)
     server = RtlSdrTcpServer(**o)
     server.run_forever()
+
 
 def test():
     import time

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -5,6 +5,7 @@ import base64
 import select
 import socket
 import struct
+import errno
 import argparse
 import traceback
 
@@ -576,9 +577,19 @@ def run_server():
 
 def test():
     import time
-    server = RtlSdrTcpServer()
-    server.run()
-    client = RtlSdrTcpClient()
+    port = 1235
+    while True:
+        try:
+            server = RtlSdrTcpServer(port=port)
+            server.run()
+        except socket.error as e:
+            if e.errno != errno.EADDRINUSE:
+                raise
+            server = None
+            port += 1
+        if server is not None:
+            break
+    client = RtlSdrTcpClient(port=port)
     test_props = [
         ['sample_rate', 2e6],
         ['center_freq', 6e6],

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -1,6 +1,7 @@
 import sys
 import threading
 import socket
+import argparse
 
 PY2 = sys.version_info[0] == 2
 if PY2:
@@ -250,3 +251,30 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
     sample_rate = rs = property(get_sample_rate, set_sample_rate)
     gain = property(get_gain, set_gain)
     freq_correction = property(get_freq_correction, set_freq_correction)
+
+def run_server():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        '-a', '--address',
+        dest='hostname',
+        metavar='address',
+        default='127.0.0.1',
+        help='Listen address (default is "127.0.0.1")')
+    p.add_argument(
+        '-p', '--port',
+        dest='port',
+        type=int,
+        default=1235,
+        help='Port to listen on (default is 1235)')
+    p.add_argument(
+        '-d', '--device-index',
+        dest='device_index',
+        type=int,
+        default=0)
+    args, remaining = p.parse_known_args()
+    o = vars(args)
+    server = RtlSdrTcpServer(**o)
+    server.run_forever()
+
+if __name__ == '__main__':
+    run_server()

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -205,13 +205,13 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
         s.close()
         return resp
     def _communicate_method(self, method_name, arg='', recv_size=1024):
-        msg = '!'.join([method_name, json.dumps(arg)])
+        msg = '!'.join([method_name, numpyjson.dumps(arg)])
         return self._communicate(msg, recv_size)
     def _communicate_descriptor(self, prop_name, value=None, recv_size=1024):
         if value is None:
             msg = '%s?' % (prop_name)
         else:
-            msg = '='.join([prop_name, json.dumps(value)])
+            msg = '='.join([prop_name, numpyjson.dumps(value)])
         return self._communicate(msg, recv_size)
     def get_center_freq(self):
         return self._communicate_descriptor('fc')

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -216,9 +216,6 @@ class ServerMessage(MessageBase):
                 sent = sock.send(data)
                 data_len -= sent
                 data = data[sent:]
-        else:
-            ack = AckMessage()
-            ack.send_message(sock)
     def get_header(self, **kwargs):
         d = super(ServerMessage, self).get_header(**kwargs)
         d['success'] = kwargs.get('success', True)

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -7,6 +7,7 @@ import struct
 import errno
 import argparse
 import traceback
+import json
 
 PY2 = sys.version_info[0] == 2
 if PY2:
@@ -15,16 +16,9 @@ else:
     from socketserver import TCPServer, BaseRequestHandler
 
 try:
-    import numpy as np
-except ImportError:
-    np = None
-
-try:
     from rtlsdr import RtlSdr
-    from helpers import numpyjson
 except ImportError:
     from .rtlsdr import RtlSdr
-    from .helpers import numpyjson
 
 MAX_BUFFER_SIZE = 4096
 
@@ -221,7 +215,7 @@ class MessageBase(object):
         message that was sent by the other end.
         """
         header = cls._recv(sock)
-        kwargs = numpyjson.loads(header)
+        kwargs = json.loads(header)
         if kwargs.get('ACK'):
             cls = AckMessage
         return cls(**kwargs)
@@ -251,10 +245,10 @@ class MessageBase(object):
     def _serialize(self):
         struct_fmt = self.header.get('struct_fmt')
         if struct_fmt is not None:
-            return numpyjson.dumps(self.header), self.data
+            return json.dumps(self.header), self.data
         data = self.header.copy()
         data.setdefault('data', self.data)
-        return numpyjson.dumps(data), None
+        return json.dumps(data), None
 
 
 
@@ -282,7 +276,7 @@ class ServerMessage(MessageBase):
 
         """
         header = cls._recv(sock)
-        kwargs = numpyjson.loads(header)
+        kwargs = json.loads(header)
         struct_fmt = kwargs.get('struct_fmt')
         if struct_fmt is not None:
             data_len = struct.calcsize(struct_fmt)

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -44,6 +44,7 @@ class RtlSdrTcpServer(RtlSdrTcpBase):
         if self.server_thread.running.is_set():
             return
         self.server_thread.start()
+        self.server_thread.running.wait()
     def run_forever(self):
         self.run()
         while True:

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -133,7 +133,7 @@ class RequestHandler(BaseRequestHandler):
     def handle_method_call(self, data):
         method_name, arg = data.split('!')
         method_name = method_name.strip()
-        arg = args.strip()
+        arg = arg.strip()
         if method_name not in API_METHODS:
             return None, None
         return self._handle_method_call(method_name, arg)

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -292,7 +292,7 @@ def test():
         ['sample_rate', 2e6],
         ['center_freq', 6e6],
         ['gain', 10.],
-        ['freq_correction', 20]
+        #['freq_correction', 20]
     ]
     try:
         gains = client.get_gains()

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -128,7 +128,6 @@ class RequestHandler(BaseRequestHandler):
             resp, resp_type = None, None
         if resp is not None:
             resp_data = self.format_response(resp, resp_type)
-            print('TX: ', resp_data)
             self.request.sendall(resp_data)
     def handle_method_call(self, data):
         method_name, arg = data.split('!')

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -262,7 +262,6 @@ class RequestHandler(BaseRequestHandler):
         rtl_sdr = self.server.rtl_sdr
         method_name = rx_message.header.get('name')
         arg = rx_message.data
-        print 'method_call: ', method_name, arg
         if method_name not in API_METHODS:
             return False
         try:
@@ -273,7 +272,6 @@ class RequestHandler(BaseRequestHandler):
             resp = m(arg)
         else:
             resp = m()
-        print '%s resp: %s' % (method_name, resp)
         tx_message = ServerMessage(client_message=rx_message, data=resp)
         tx_message.send_message(self.request)
     def handle_prop_set(self, rx_message):
@@ -281,7 +279,6 @@ class RequestHandler(BaseRequestHandler):
         prop_name = rx_message.header.get('name')
         value = rx_message.data
         api_data = API_DESCRIPTORS.get(prop_name)
-        print 'prop_set: ', prop_name, value, api_data
         if api_data is None:
             return False
         setattr(rtl_sdr, prop_name, value)

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python
+
 import sys
 import time
 import threading

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -104,28 +104,22 @@ class Server(TCPServer):
         server_addr = (rtl_sdr.hostname, rtl_sdr.port)
         TCPServer.__init__(self, server_addr, RequestHandler)
 
-API_METHODS = {
-    'get_center_freq':{'return_type':float},
-    'set_center_freq':{'args':float},
-    'get_sample_rate':{'return_type':float},
-    'set_sample_rate':{'args':float},
-    'get_gain':{'return_type':'float'},
-    'set_gain':{'args':[float, str]},
-    'get_freq_correction':{'return_type':int},
-    'set_freq_correction':{'args':int},
-    'get_gains':{'return_type':list},
-    'get_tuner_type':{'return_type':int},
-    'set_direct_sampling':{'args':bool},
-    'read_samples':{'args':int, 'return_type':'numpy'},
-    'read_samples_async':{'args':int, 'return_type':'numpy'}
-}
+API_METHODS = (
+    'get_center_freq', 'set_center_freq',
+    'get_sample_rate', 'set_sample_rate',
+    'get_gain', 'set_gain',
+    'get_freq_correction', 'set_freq_correction',
+    'get_gains',
+    'get_tuner_type',
+    'set_direct_sampling',
+    'read_samples',
+    'read_samples_async',
+)
 API_DESCRIPTORS = {
-    'center_freq':('get_center_freq', 'set_center_freq'),
-    'fc':('get_center_freq', 'set_center_freq'),
-    'sample_rate':('get_sample_rate', 'set_sample_rate'),
-    'rs':('get_sample_rate', 'set_sample_rate'),
-    'gain':('get_gain', 'set_gain'),
-    'freq_correction':('get_freq_correction', 'set_freq_correction')
+    'center_freq', 'fc',
+    'sample_rate', 'rs',
+    'gain',
+    'freq_correction',
 }
 
 class MessageBase(object):
@@ -293,16 +287,14 @@ class RequestHandler(BaseRequestHandler):
         rtl_sdr = self.server.rtl_sdr
         prop_name = rx_message.header.get('name')
         value = rx_message.data
-        api_data = API_DESCRIPTORS.get(prop_name)
-        if api_data is None:
+        if prop_name not in API_DESCRIPTORS:
             return False
         setattr(rtl_sdr, prop_name, value)
         tx_message = ServerMessage(client_message=rx_message)
         tx_message.send_message(self.request)
     def handle_prop_get(self, rx_message):
         prop_name = rx_message.header.get('name')
-        api_data = API_DESCRIPTORS.get(prop_name)
-        if api_data is None:
+        if prop_name not in API_DESCRIPTORS:
             return False
         rtl_sdr = self.server.rtl_sdr
         value = getattr(rtl_sdr, prop_name)

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -180,7 +180,7 @@ class RequestHandler(BaseRequestHandler):
         api_data = API_DESCRIPTORS.get(prop_name)
         if api_data is None:
             return None, None
-        method_name = API_METHODS.get(api_data[1])
+        method_name = api_data[1]
         return self._handle_method_call(method_name, value)
     def handle_prop_get(self, data):
         prop_name = data.split('?')[0].strip()

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -138,7 +138,11 @@ class MessageBase(object):
     @classmethod
     def from_remote(cls, sock):
         header = sock.recv(MAX_BUFFER_SIZE)
-        kwargs = numpyjson.loads(header)
+        try:
+            kwargs = numpyjson.loads(header)
+        except ValueError:
+            print(header)
+            raise
         if kwargs.get('ACK'):
             cls = AckMessage
         return cls(**kwargs)
@@ -197,7 +201,11 @@ class ServerMessage(MessageBase):
     @classmethod
     def from_remote(cls, sock):
         header = sock.recv(MAX_BUFFER_SIZE)
-        kwargs = numpyjson.loads(header)
+        try:
+            kwargs = numpyjson.loads(header)
+        except ValueError:
+            print(header)
+            raise
         data_len = kwargs.get('data_len')
         data = kwargs.get('data')
         if data_len is None or data is not None:

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -310,7 +310,7 @@ def test():
         ['sample_rate', 2e6],
         ['center_freq', 6e6],
         ['gain', 10.],
-        #['freq_correction', 20]
+        ['freq_correction', 20]
     ]
     try:
         gains = client.get_gains()

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -196,6 +196,8 @@ class RequestHandler(BaseRequestHandler):
 class RtlSdrTcpClient(RtlSdrTcpBase):
     def open(self, *args):
         self.device_opened = True
+    def close(self):
+        self.device_opened = False
     def _build_socket(self):
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         s.connect((self.hostname, self.port))

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -201,11 +201,7 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
         if resp:
             resp = numpyjson.loads(resp)
             if isinstance(resp, dict):
-                t = resp.get('type')
-                if t in ["<type '%s'>" % (tname) for tname in ['float', 'int', 'str']]:
-                    t = t.split("'")[1]
-                    t = eval(t)
-                    resp = t(resp['value'])
+                resp = resp['value']
         s.close()
         return resp
     def _communicate_method(self, method_name, arg='', recv_size=1024):

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -1,0 +1,188 @@
+import sys
+import threading
+
+PY2 = sys.version_info[0] == 2
+if PY2:
+    from SocketServer import TCPServer, BaseRequestHandler
+else:
+    from socketserver import TCPServer, BaseRequestHandler
+
+try:
+    from rtlsdr import RtlSdr
+    from helpers import numpyjson
+except ImportError:
+    from .rtlsdr import RtlSdr
+    from .helpers import numpyjson
+
+
+class RtlSdrTcpBase(RtlSdr):
+    # Use port 1235 as default since rtl_tcp uses 1234
+    DEFAULT_PORT = 1235
+
+    def __init__(self, device_index=0, test_mode_enabled=False,
+                 hostname='127.0.0.1', port=None):
+        self.device_index = device_index
+        self.test_mode_enabled = test_mode_enabled
+        self.hostname = hostname
+        self.port = port
+        if self.port is None:
+            self.port = self.DEFAULT_PORT
+        self.device_ready = False
+        self.server_thread = None
+        super(RtlSdrTcpBase, self).__init__(device_index, test_mode_enabled)
+
+class RtlSdrTcpServer(RtlSdrTcpBase):
+    def open(self, device_index=0, test_mode_enabled=False):
+        if not self.device_ready:
+            if self.server_thread is None:
+                self.build_server()
+            return
+        super(RtlSdrTcpServer, self).open(device_index, test_mode_enabled)
+    def build_server(self):
+        self.server_thread = ServerThread(self)
+    def run_forever(self):
+        self.server_thread.start()
+        while True:
+            try:
+                self.server_thread.stopped.wait(1.)
+            except KeyboardInterrupt:
+                self.close()
+                break
+    def close(self):
+        self.server_thread.stop()
+        super(RtlSdrTcpServer, self).close()
+
+class ServerThread(threading.Thread):
+    def __init__(self, rtl_sdr):
+        super(ServerThread, self).__init__()
+        self.rtl_sdr = rtl_sdr
+        self.running = threading.Event()
+        self.stopped = threading.Event()
+    def run(self):
+        self.server = Server(self.rtl_sdr)
+        rtl_sdr = self.rtl_sdr
+        rtl_sdr.device_ready = True
+        rtl_sdr.open(rtl_sdr.device_index, rtl_sdr.test_mode_enabled)
+        self.running.set()
+        self.server.serve_forever()
+        self.running.clear()
+        self.stopped.set()
+    def stop(self):
+        self.server.shutdown()
+        self.stopped.wait()
+
+class Server(TCPServer):
+    REQUEST_RECV_SIZE = 1024
+    def __init__(self, rtl_sdr):
+        self.rtl_sdr = rtl_sdr
+        server_addr = (rtl_sdr.hostname, rtl_sdr.port)
+        TCPServer.__init__(self, server_addr, RequestHandler)
+
+API_METHODS = {
+    'get_center_freq':{'return_type':float},
+    'set_center_freq':{'args':float},
+    'get_sample_rate':{'return_type':float},
+    'set_sample_rate':{'args':float},
+    'get_gain':{'return_type':'float'},
+    'set_gain':{'args':[float, str]},
+    'get_freq_correction':{'return_type':int},
+    'set_freq_correction':{'args':int},
+    'get_gains':{'return_type':list},
+    'get_tuner_type':{'return_type':int},
+    'set_direct_sampling':{'args':bool},
+    'read_samples':{'args':int, 'return_type':'numpy'},
+    'read_samples_async':{'args':int, 'return_type':'numpy'}
+}
+API_DESCRIPTORS = {
+    'center_freq':('get_center_freq', 'set_center_freq'),
+    'fc':('get_center_freq', 'set_center_freq'),
+    'sample_rate':('get_sample_rate', 'set_sample_rate'),
+    'rs':('get_sample_rate', 'set_sample_rate'),
+    'gain':('get_gain', 'set_gain'),
+    'freq_correction':('get_freq_correction', 'set_freq_correction')
+}
+
+class RequestHandler(BaseRequestHandler):
+    '''Expected data:
+        Method call with arg:
+            method_name!arg
+        Method call without arg:
+            method_name!
+        Descriptor set:
+            descriptor_name=value
+        Descriptor get:
+            descriptor_name?
+    '''
+    def handle(self):
+        recv_size = self.server.REQUEST_RECV_SIZE
+        data = self.data = self.request.recv(recv_size)
+        print('RX: ', data)
+        if '!' in data:
+            resp, resp_type = self.handle_method_call(data)
+        elif '=' in data:
+            resp, resp_type = self.handle_prop_set(data)
+        elif '?' in data:
+            resp, resp_type = self.handle_prop_get(data)
+        else:
+            resp, resp_type = None, None
+        if resp is not None:
+            resp_data = self.format_response(resp, resp_type)
+            print('TX: ', resp_data)
+            self.request.sendall(resp_data)
+    def handle_method_call(self, data):
+        method_name, arg = data.split('!')
+        method_name = method_name.strip()
+        arg = args.strip()
+        if method_name not in API_METHODS:
+            return None, None
+        return self._handle_method_call(method_name, arg)
+    def _handle_method_call(self, method_name, arg):
+        rtl_sdr = self.server.rtl_sdr
+        api_data = API_METHODS.get(method_name)
+        try:
+            m = getattr(rtl_sdr, method_name.strip())
+        except AttributeError:
+            return None, None
+        if 'args' in api_data and not arg:
+            return None, None
+        _arg = None
+        if isinstance(api_data['args'], list):
+            for arg_type in api_data['args']:
+                try:
+                    _arg = arg_type(arg)
+                except ValueError:
+                    _arg = None
+                if _arg is not None:
+                    break
+            if _arg is None:
+                return None, None
+        elif 'args' in api_data:
+            try:
+                _arg = api_data['args'](arg)
+            except ValueError:
+                return None, None
+        if _arg is not None:
+            resp = m(_arg)
+        else:
+            resp = m()
+        return resp, api_data.get('return_type')
+    def handle_prop_set(self, data):
+        prop_name, value = data.split('=')
+        prop_name = prop_name.strip()
+        value = value.strip()
+        api_data = API_DESCRIPTORS.get(prop_name)
+        if api_data is None:
+            return None, None
+        method_name = API_METHODS.get(api_data[1])
+        return self._handle_method_call(method_name, value)
+    def handle_prop_get(self, data):
+        prop_name = data.split('?')[0].strip()
+        api_data = API_DESCRIPTORS.get(prop_name)
+        if api_data is None:
+            return None, None
+        rtl_sdr = self.server.rtl_sdr
+        value = getattr(rtl_sdr, prop_name)
+        resp_type = API_METHODS.get(api_data[0], {}).get('return_type')
+        return value, resp_type
+    def format_response(self, resp, resp_type):
+        return numpyjson.dumps({'type':str(resp_type), 'value':resp})

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -105,16 +105,19 @@ class RtlSdrTcpServer(RtlSdrTcpBase):
         super(RtlSdrTcpServer, self).close()
 
     def read_bytes(self, num_bytes=RtlSdr.DEFAULT_READ_SIZE):
+        """Return a packed string of bytes read along with the struct_fmt.
+        """
         fmt_str = '%dB' % (num_bytes)
         buffer = super(RtlSdrTcpServer, self).read_bytes(num_bytes)
         s = struct.pack(fmt_str, *buffer)
         return {'struct_fmt':fmt_str, 'data':s}
 
     def read_samples(self, num_samples=RtlSdr.DEFAULT_READ_SIZE):
+        """This overrides the base implementation so that the raw data is sent.
+        It will be unpacked to I/Q samples on the client side.
+        """
         num_samples = 2*num_samples
         return self.read_bytes(num_samples)
-
-
 
 class ServerThread(threading.Thread):
     def __init__(self, rtl_sdr):


### PR DESCRIPTION
This is currently a WIP, but I thought I might open it as a PR to get some collaboration as far as structure, etc is concerned.

I've built subclasses for both servers and clients and so far have been able to successfully communicate between the two (setting sample_rate, center_freq, reading samples, etc)

The general idea I had was to allow a client computer or device (mobile perhaps) to utilize the library without the need for the underlying librtlsdr installed.  This would be a future step since all of it is required at import time, but could be easily refactored.

I'd appreciate any feedback!