### PR TITLE
Returned gain of zero may not be an error

### DIFF
--- a/rtlsdr/rtlsdr.py
+++ b/rtlsdr/rtlsdr.py
@@ -207,11 +207,6 @@ class BaseRtlSdr(object):
     def get_gain(self):
         ''' Get gain of tuner (in dB). '''
 
-        result = librtlsdr.rtlsdr_get_tuner_gain(self.dev_p)
-        if result == 0:
-            self.close()
-            raise IOError('Error when getting gain')
-
         return result/10
 
     def get_gains(self):


### PR DESCRIPTION
R820T tuners can have a gain of zero even though the driver returns 0 under error conditions.

Debatable if if this should be merged until the problem is [fixed in the driver](https://github.com/steve-m/librtlsdr/issues/24)