### PR TITLE
Only override the install_lib command in distutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
   - cd build-ext
   - ./install-librtlsdr.sh
   - cd ..
+  - export LD_LIBRARY_PATH=$HOME/.local:$LD_LIBRARY_PATH
 install:
   - pip install -e .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+addons:
+  apt:
+    packages:
+      - libusb-1.0-0-dev
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libusb-1.0-0-dev
   - cd build-ext
   - ./install-librtlsdr.sh
   - cd ..

--- a/build-ext/install-librtlsdr.sh
+++ b/build-ext/install-librtlsdr.sh
@@ -7,7 +7,7 @@ RELEASE=${1:-$DEFAULT_RELEASE}
 TAR_FILE="v$RELEASE.tar.gz"
 PKG_URL="https://github.com/steve-m/librtlsdr/archive/$TAR_FILE"
 
-if [ "$TRAVIS" = "true"]; then
+if [ "$TRAVIS" = "true" ]; then
   set -ex
 fi
 
@@ -23,7 +23,7 @@ tar xvzf $TAR_FILE
 cd "librtlsdr-$RELEASE"
 mkdir build
 cd build
-if [ "$TRAVIS" = "true"]; then
+if [ "$TRAVIS" = "true" ]; then
   cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DLIB_INSTALL_DIR=$HOME/.local/ ../
   make
   make install

--- a/build-ext/install-librtlsdr.sh
+++ b/build-ext/install-librtlsdr.sh
@@ -25,5 +25,3 @@ mkdir build
 cd build
 cmake ../
 make
-sudo make install
-sudo ldconfig

--- a/build-ext/install-librtlsdr.sh
+++ b/build-ext/install-librtlsdr.sh
@@ -23,6 +23,12 @@ tar xvzf $TAR_FILE
 cd "librtlsdr-$RELEASE"
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DLIB_INSTALL_DIR=$HOME/.local/ ../
-make
-make install
+if [ "$TRAVIS" = "true"]; then
+  cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DLIB_INSTALL_DIR=$HOME/.local/ ../
+  make
+  make install
+else
+  cmake ../
+  make
+  sudo make install
+fi

--- a/build-ext/install-librtlsdr.sh
+++ b/build-ext/install-librtlsdr.sh
@@ -23,5 +23,6 @@ tar xvzf $TAR_FILE
 cd "librtlsdr-$RELEASE"
 mkdir build
 cd build
-cmake ../
+cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DLIB_INSTALL_DIR=$HOME/.local/ ../
 make
+make install

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import sys
 
-collect_ignore = ['setup.py']
+collect_ignore = ['setup.py', 'demo_waterfall.py']
 
 ASYNC_AVAILABLE = sys.version_info.major >= 3
 if sys.version_info.major == 3:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = rtlsdr
 python_files = *.py
+ignore = demo_waterfall.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 testpaths = rtlsdr
 python_files = *.py
-ignore = demo_waterfall.py

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,9 @@ import re
 try:
     from setuptools import setup
     from setuptools.command.install_lib import install_lib as _install_lib
-    from setuptools.command.build_py import build_py as _build_py
 except ImportError:
     from distutils.core import setup
     from distutils.command.install_lib import install_lib as _install_lib
-    from distutils.command.build_py import build_py as _build_py
 
 PACKAGE_NAME = 'pyrtlsdr'
 VERSION = '0.1.1'
@@ -39,21 +37,6 @@ class install_lib(_install_lib):
         if not ASYNC_AVAILABLE:
             files = [f for f in files if 'rtlsdraio.py' not in f]
         _install_lib.byte_compile(self, files)
-
-class build_py(_build_py):
-    def _filter_modules(self, modules):
-        if ASYNC_AVAILABLE:
-            return modules
-        return [m for m in modules if 'rtlsdraio' not in m]
-    def find_package_modules(self, package, package_dir):
-        modules = _build_py.find_package_modules(self, package, package_dir)
-        return self._filter_modules(modules)
-    def find_modules(self):
-        modules = _build_py.find_modules(self)
-        return self._filter_modules(modules)
-    def find_all_modules(self):
-        modules = _build_py.find_all_modules(self)
-        return self._filter_modules(modules)
 
 #HERE = os.path.abspath(os.path.dirname(__file__))
 #README = open(os.path.join(HERE, 'README.md')).read()
@@ -78,6 +61,5 @@ setup(
     keywords='radio librtlsdr rtlsdr sdr',
     cmdclass={
         'install_lib':install_lib,
-        'build_py':build_py,
     },
     packages=['rtlsdr'])


### PR DESCRIPTION
Maintains the full source package but still avoids byte-compiling py3.5+ code.

Previously the `rtlsdraio` module would not be included in the install.