### PR TITLE
Use relative imports only

### DIFF
--- a/rtlsdr/__init__.py
+++ b/rtlsdr/__init__.py
@@ -15,19 +15,12 @@
 #    along with pyrlsdr.  If not, see <http://www.gnu.org/licenses/>.
 
 
-try:                from  librtlsdr import librtlsdr
-except ImportError: from .librtlsdr import librtlsdr
-try:                from  rtlsdr import RtlSdr
-except ImportError: from .rtlsdr import RtlSdr
-try:                from rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
-except ImportError: from .rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
-try:                from  helpers import limit_calls, limit_time
-except ImportError: from .helpers import limit_calls, limit_time
 
-try:
-    from rtlsdraio import RtlSdrAio, AIO_AVAILABLE
-except ImportError:
-    from .rtlsdraio import RtlSdrAio, AIO_AVAILABLE
+from .librtlsdr import librtlsdr
+from .rtlsdr import RtlSdr
+from .rtlsdrtcp import RtlSdrTcpServer, RtlSdrTcpClient
+from .helpers import limit_calls, limit_time
+from .rtlsdraio import RtlSdrAio, AIO_AVAILABLE
 
 if AIO_AVAILABLE:
     RtlSdr = RtlSdrAio

--- a/rtlsdr/rtlsdr.py
+++ b/rtlsdr/rtlsdr.py
@@ -17,8 +17,7 @@
 
 from __future__ import division, print_function
 from ctypes import *
-try:                from  librtlsdr import librtlsdr, p_rtlsdr_dev, rtlsdr_read_async_cb_t
-except ImportError: from .librtlsdr import librtlsdr, p_rtlsdr_dev, rtlsdr_read_async_cb_t
+from .librtlsdr import librtlsdr, p_rtlsdr_dev, rtlsdr_read_async_cb_t
 try:                from itertools import izip
 except ImportError: izip = zip
 import sys

--- a/rtlsdr/rtlsdraio.py
+++ b/rtlsdr/rtlsdraio.py
@@ -4,10 +4,7 @@ try:
     AIO_AVAILABLE = True
 except ImportError:
     AIO_AVAILABLE = False
-try:
-    from rtlsdr import RtlSdr
-except ImportError:
-    from .rtlsdr import RtlSdr as _RtlSdr
+from .rtlsdr import RtlSdr
 
 
 log = logging.getLogger(__name__)

--- a/rtlsdr/rtlsdrtcp.py
+++ b/rtlsdr/rtlsdrtcp.py
@@ -17,10 +17,7 @@ if PY2:
 else:
     from socketserver import TCPServer, BaseRequestHandler
 
-try:
-    from rtlsdr import RtlSdr
-except ImportError:
-    from .rtlsdr import RtlSdr
+from .rtlsdr import RtlSdr
 
 
 MAX_BUFFER_SIZE = 4096


### PR DESCRIPTION
Dotted imports work on all targeted python versions, so the `try: ... except:` clauses can be safely removed