### PR TITLE
[WIP] Error code tests

### DIFF
--- a/rtlsdr/librtlsdr.py
+++ b/rtlsdr/librtlsdr.py
@@ -58,6 +58,7 @@ f.restype, f.argtypes = c_char_p, [c_uint]
 
 # int rtlsdr_get_device_usb_strings(uint32_t index, char *manufact,
 #                                   char *product, char *serial)
+# * \return 0 on success
 f = librtlsdr.rtlsdr_get_device_usb_strings
 f.restype, f.argtypes = c_int, [c_uint,
                                 POINTER(c_ubyte),
@@ -65,69 +66,89 @@ f.restype, f.argtypes = c_int, [c_uint,
                                 POINTER(c_ubyte)]
 
 # int rtlsdr_open(rtlsdr_dev_t **dev, uint32_t index);
+# FIXME: return value not documented
 f = librtlsdr.rtlsdr_open
 f.restype, f.argtypes = c_int, [POINTER(p_rtlsdr_dev), c_uint]
 
 # int rtlsdr_close(rtlsdr_dev_t *dev);
+# FIXME: return value not documented
 f = librtlsdr.rtlsdr_close
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev]
 
 # /* configuration functions */
 
 # int rtlsdr_set_center_freq(rtlsdr_dev_t *dev, uint32_t freq);
+# * \return 0 on error, frequency in Hz otherwise
 f = librtlsdr.rtlsdr_set_center_freq
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_uint]
 
 # int rtlsdr_get_center_freq(rtlsdr_dev_t *dev);
+# * \return 0 on error, frequency in Hz otherwise
 f = librtlsdr.rtlsdr_get_center_freq
 f.restype, f.argtypes = c_uint, [p_rtlsdr_dev]
 
 # int rtlsdr_set_freq_correction(rtlsdr_dev_t *dev, int ppm);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_freq_correction
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_int]
 
 # int rtlsdr_get_freq_correction(rtlsdr_dev_t *dev);
+# * \return correction value in parts per million (ppm)
+# NOTE: no return value indicated as an error
 f = librtlsdr.rtlsdr_get_freq_correction
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev]
 
 # enum rtlsdr_tuner rtlsdr_get_tuner_type(rtlsdr_dev_t *dev);
+# * \return RTLSDR_TUNER_UNKNOWN on error, tuner type otherwise
+# NOTE: RTLSDR_TUNER_UNKNOWN == 0
 f = librtlsdr.rtlsdr_get_tuner_type
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev]
 
 # int rtlsdr_set_tuner_gain(rtlsdr_dev_t *dev, int gain);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_tuner_gain
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_int]
 
 # int rtlsdr_get_tuner_gain(rtlsdr_dev_t *dev);
+# * \return 0 on error, gain in tenths of a dB, 115 means 11.5 dB.
+# NOTE: This description is still seemingly incorrect. Issue should be re-raised
 f = librtlsdr.rtlsdr_get_tuner_gain
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev]
 
 # int rtlsdr_get_tuner_gains(rtlsdr_dev_t *dev, int *gains)
+# * \return <= 0 on error, number of available (returned) gain values otherwise
 f = librtlsdr.rtlsdr_get_tuner_gains
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, POINTER(c_int)]
 
 # RTLSDR_API int rtlsdr_set_tuner_gain_mode(rtlsdr_dev_t *dev, int manual);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_tuner_gain_mode
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_int]
 
 # RTLSDR_API int rtlsdr_set_agc_mode(rtlsdr_dev_t *dev, int on);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_agc_mode
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_int]
 
 # RTLSDR_API  int rtlsdr_set_direct_sampling(rtlsdr_dev_t *dev, int on)
+# * \return -1 on error, 0 means disabled, 1 I-ADC input enabled
+#            2 Q-ADC input enabled
 f = librtlsdr.rtlsdr_set_direct_sampling
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_int]
 
 
 # int rtlsdr_set_sample_rate(rtlsdr_dev_t *dev, uint32_t rate);
+# * \return 0 on success, -EINVAL on invalid rate
 f = librtlsdr.rtlsdr_set_sample_rate
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_uint]
 
 # int rtlsdr_get_sample_rate(rtlsdr_dev_t *dev);
+# * \return 0 on error, sample rate in Hz otherwise
 f = librtlsdr.rtlsdr_get_sample_rate
 f.restype, f.argtypes = c_uint, [p_rtlsdr_dev]
 
 # int rtlsdr_set_and_get_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw, uint32_t *applied_bw, int apply_bw );
+# * \return 0 on success
 try:
     f = librtlsdr.rtlsdr_set_and_get_tuner_bandwidth
     f.restype, f.argtypes = c_uint, [p_rtlsdr_dev, c_uint32, POINTER(c_uint32), c_int]
@@ -136,20 +157,24 @@ except AttributeError:
     tuner_bandwidth_supported = False
 
 # int rtlsdr_set_tuner_bandwidth(rtlsdr_dev_t *dev, uint32_t bw);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_tuner_bandwidth
 f.restype, f.argtypes = c_uint, [p_rtlsdr_dev, c_uint]
 
 #/* streaming functions */
 
 # int rtlsdr_reset_buffer(rtlsdr_dev_t *dev);
+# FIXME: return value not documented
 f = librtlsdr.rtlsdr_reset_buffer
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev]
 
 # int rtlsdr_read_sync(rtlsdr_dev_t *dev, void *buf, int len, int *n_read);
+# FIXME: return value not documented
 f = librtlsdr.rtlsdr_read_sync
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_void_p, c_int, POINTER(c_int)]
 
 # int rtlsdr_wait_async(rtlsdr_dev_t *dev, rtlsdr_read_async_cb_t cb, void *ctx);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_wait_async
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, POINTER(rtlsdr_read_async_cb_t), py_object]
 
@@ -158,24 +183,29 @@ f.restype, f.argtypes = c_int, [p_rtlsdr_dev, POINTER(rtlsdr_read_async_cb_t), p
 #				 void *ctx,
 #				 uint32_t buf_num,
 #				 uint32_t buf_len);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_read_async
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, rtlsdr_read_async_cb_t, py_object, c_uint, c_uint]
 
 # int rtlsdr_cancel_async(rtlsdr_dev_t *dev);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_cancel_async
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev]
 
 # RTLSDR_API int rtlsdr_set_xtal_freq(rtlsdr_dev_t *dev, uint32_t rtl_freq,
 #				    uint32_t tuner_freq);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_xtal_freq
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_uint, c_uint]
 
 # RTLSDR_API int rtlsdr_get_xtal_freq(rtlsdr_dev_t *dev, uint32_t *rtl_freq,
 #				    uint32_t *tuner_freq);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_get_xtal_freq
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, POINTER(c_uint), POINTER(c_uint)]
 
 # RTLSDR_API int rtlsdr_set_testmode(rtlsdr_dev_t *dev, int on);
+# * \return 0 on success
 f = librtlsdr.rtlsdr_set_testmode
 f.restype, f.argtypes = c_int, [p_rtlsdr_dev, c_int]
 

--- a/rtlsdr/rtlsdr.py
+++ b/rtlsdr/rtlsdr.py
@@ -74,7 +74,7 @@ class BaseRtlSdr(object):
 
         # enable test mode if necessary
         result = librtlsdr.rtlsdr_set_testmode(self.dev_p, int(test_mode_enabled))
-        if result < 0:
+        if result != 0:
             raise IOError('Error code %d when setting test mode'\
                           % (result))
 
@@ -113,7 +113,7 @@ class BaseRtlSdr(object):
         freq = int(freq)
 
         result = librtlsdr.rtlsdr_set_center_freq(self.dev_p, freq)
-        if result < 0:
+        if result == 0:
             self.close()
             raise IOError('Error code %d when setting center freq. to %d Hz'\
                           % (result, freq))
@@ -124,7 +124,7 @@ class BaseRtlSdr(object):
         ''' Return center frequency of tuner (in Hz). '''
 
         result = librtlsdr.rtlsdr_get_center_freq(self.dev_p)
-        if result < 0:
+        if result == 0:
             self.close()
             raise IOError('Error code %d when getting center freq.'\
                           % (result))
@@ -141,7 +141,7 @@ class BaseRtlSdr(object):
         freq = int(err_ppm)
 
         result = librtlsdr.rtlsdr_set_freq_correction(self.dev_p, err_ppm)
-        if result < 0:
+        if result != 0:
             self.close()
             raise IOError('Error code %d when setting freq. offset to %d ppm'\
                           % (result, err_ppm))
@@ -176,7 +176,7 @@ class BaseRtlSdr(object):
         ''' Get sample rate of tuner (in Hz) '''
 
         result = librtlsdr.rtlsdr_get_sample_rate(self.dev_p)
-        if result < 0:
+        if result == 0:
             self.close()
             raise IOError('Error code %d when getting sample rate'\
                           % (result))
@@ -241,7 +241,7 @@ class BaseRtlSdr(object):
 
         result = librtlsdr.rtlsdr_set_tuner_gain(self.dev_p,
                                                  self.gain_values[nearest_gain_ind])
-        if result < 0:
+        if result != 0:
             self.close()
             raise IOError('Error code %d when setting gain to %d'\
                           % (result, gain))
@@ -252,6 +252,7 @@ class BaseRtlSdr(object):
         ''' Get gain of tuner (in dB). '''
 
         result = librtlsdr.rtlsdr_get_tuner_gain(self.dev_p)
+        # TODO: Determine what the real error value should be from librtlsdr
         if 0 and result == 0:
             self.close()
             raise IOError('Error when getting gain')
@@ -264,7 +265,7 @@ class BaseRtlSdr(object):
         '''
         buffer = (c_int *50)()
         result = librtlsdr.rtlsdr_get_tuner_gains(self.dev_p, buffer)
-        if result == 0:
+        if result <= 0:
             self.close()
             raise IOError('Error when getting gains')
 
@@ -280,7 +281,7 @@ class BaseRtlSdr(object):
         this directly.
         '''
         result = librtlsdr.rtlsdr_set_tuner_gain_mode(self.dev_p, int(enabled))
-        if result < 0:
+        if result != 0:
             raise IOError('Error code %d when setting gain mode'\
                           % (result))
 
@@ -290,7 +291,7 @@ class BaseRtlSdr(object):
         ''' Enable RTL2832 AGC
         '''
         result = librtlsdr.rtlsdr_set_agc_mode(self.dev_p, int(enabled))
-        if result < 0:
+        if result != 0:
             raise IOError('Error code %d when setting AGC mode'\
                           % (result))
 
@@ -328,7 +329,7 @@ class BaseRtlSdr(object):
         ''' Get the tuner type.
         '''
         result = librtlsdr.rtlsdr_get_tuner_type(self.dev_p)
-        if result < 0:
+        if result == 0:
             raise IOError('Error code %d when getting tuner type'\
                           % (result))
 
@@ -428,7 +429,7 @@ class RtlSdr(BaseRtlSdr):
         self.read_async_canceling = False
         result = librtlsdr.rtlsdr_read_async(self.dev_p, rtlsdr_callback,\
                     context, self.DEFAULT_ASYNC_BUF_NUMBER, num_bytes)
-        if result < 0:
+        if result != 0:
             self.close()
             raise IOError('Error code %d when requesting %d bytes'\
                           % (result, num_bytes))
@@ -472,7 +473,7 @@ class RtlSdr(BaseRtlSdr):
         result = librtlsdr.rtlsdr_cancel_async(self.dev_p)
         # sometimes we get additional callbacks after canceling an async read,
         # in this case we don't raise exceptions
-        if result < 0 and not self.read_async_canceling:
+        if result != 0 and not self.read_async_canceling:
             self.close()
             raise IOError('Error code %d when canceling async read'\
                           % (result))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,9 @@ if not ASYNC_AVAILABLE:
 def is_travisci():
     return all([os.environ.get(key) == 'true' for key in ['CI', 'TRAVIS']])
 
+if not is_travisci():
+    collect_ignore.append('test_basic.py::test_lib_error_codes')
+
 @pytest.fixture(params=[True, False])
 def tuner_bandwidth_supported(request, monkeypatch):
     return request.param
@@ -45,6 +48,15 @@ def use_numpy(request, monkeypatch):
         monkeypatch.setattr('rtlsdr.rtlsdr.has_numpy', False)
         monkeypatch.setattr('rtlsdr.rtlsdrtcp.base.has_numpy', False)
     return request.param
+
+@pytest.fixture
+def librtlsdr_error_checking(request, monkeypatch):
+    from rtlsdr.rtlsdr import RtlSdr, librtlsdr
+    def reset_librtlsdr():
+        librtlsdr.fail_tests = False
+        librtlsdr.fail_tests_on_open = False
+    request.addfinalizer(reset_librtlsdr)
+    return (RtlSdr, librtlsdr)
 
 @pytest.fixture
 def sdr_cls():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+import pytest
 
 def test_pkg_version():
     import subprocess
@@ -15,3 +16,45 @@ def test(sdr_cls, use_numpy):
     sdr = sdr_cls()
     generic_test(sdr, use_numpy=use_numpy)
     sdr.close()
+
+def test_lib_error_codes(librtlsdr_error_checking):
+    RtlSdr, librtlsdr = librtlsdr_error_checking
+
+    librtlsdr.fail_tests_on_open = True
+    with pytest.raises(IOError):
+        sdr = RtlSdr()
+
+    librtlsdr.fail_tests_on_open = False
+    librtlsdr.fail_tests = True
+
+    with pytest.raises(IOError, message='Error code -1 when setting test mode'):
+        sdr = RtlSdr(test_mode_enabled=True)
+    with pytest.raises(IOError, message='Error code -1 when resetting buffer (device index = 0)'):
+        sdr = RtlSdr()
+
+    librtlsdr.fail_tests = False
+    sdr = RtlSdr()
+    librtlsdr.fail_tests = True
+
+    fc = 90e6
+    with pytest.raises(IOError, message='Error code -1 when setting center freq. to %d Hz' % (fc)):
+        sdr.fc = fc
+    with pytest.raises(IOError, message='Error code 0 when getting center freq.'):
+        sdr.get_center_freq()
+    with pytest.raises(IOError, message='Error code -1 when setting freq. offset to 10 ppm'):
+        sdr.set_freq_correction(10)
+
+    ## TODO: There is no return value documented as an 'error'
+    ## (which would make sense if you had a negative offset in PPM)
+    # with pytest.raises(IOError, message='Error code ? when getting freq. offset in ppm.'):
+    #     sdr.get_freq_correction()
+
+    rs = 2e6
+    with pytest.raises(IOError, message='Error code -1 when setting sample rate to %d Hz' % (rs)):
+        sdr.rs = rs
+
+    with pytest.raises(IOError, message='Error code 0 when getting sample rate'):
+        sdr.get_sample_rate()
+
+    with pytest.raises(IOError, message='Error when getting gains'):
+        gains = sdr.get_gains()


### PR DESCRIPTION
Initially for the sake of code coverage, I decided to write tests against the return values from `librtlsdr`.

In sorting through the [api](https://github.com/librtlsdr/librtlsdr/blob/master/include/rtl-sdr.h) I found a couple of discrepancies between what was documented and how `pyrtlsdr` is checking for the return values.

The return values are added as comments with each block of wrapper code to make things easier.  A few things that were undocumented, or need clarification from the `librtlsdr` developers are noted, but I intend to raise issues accordingly.