### PR TITLE
don't invoke ctypes.utils.find_library unless necessary

### DIFF
--- a/rtlsdr/librtlsdr.py
+++ b/rtlsdr/librtlsdr.py
@@ -15,18 +15,27 @@
 #    along with pyrlsdr.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import sys
+import os
 from ctypes import *
 from ctypes.util import find_library
 
 def load_librtlsdr():
-    driver_files = ['rtlsdr.dll', 'librtlsdr.so']
+    if sys.platform == "linux" and 'LD_LIBRARY_PATH' in os.environ.keys():
+        ld_library_paths = [local_path for local_path in os.environ['LD_LIBRARY_PATH'].split(':') if local_path.strip()]
+        driver_files = [local_path + '/librtlsdr.so' for local_path in ld_library_paths]
+    else:
+        driver_files = []
+    driver_files += ['librtlsdr.so', 'rtlsdr/librtlsdr.so']
+    driver_files += ['rtlsdr.dll', 'librtlsdr.so']
     driver_files += ['..//rtlsdr.dll', '..//librtlsdr.so']
     driver_files += ['rtlsdr//rtlsdr.dll', 'rtlsdr//librtlsdr.so']
-    driver_files += [find_library('rtlsdr'), find_library('librtlsdr')]
-
+    driver_files += [lambda : find_library('rtlsdr'), lambda : find_library('librtlsdr')]
     dll = None
 
     for driver in driver_files:
+        if callable(driver):
+            driver = callable(driver)
         try:
             dll = CDLL(driver)
             break

--- a/rtlsdr/librtlsdr.py
+++ b/rtlsdr/librtlsdr.py
@@ -35,7 +35,7 @@ def load_librtlsdr():
 
     for driver in driver_files:
         if callable(driver):
-            driver = callable(driver)
+            driver = driver()
         try:
             dll = CDLL(driver)
             break


### PR DESCRIPTION
`ctypes.utils.find_library` on Linux is a heavyweight helper function that invokes GCC and a number of other bits of the compiler/linker/introspection toolchain to find the path of `librtlsdr.so` - as such, it seems advantageous to not call this function unless it's necessary. 

`find_library` fails on some of the embedded systems on which I'm working to deploy pyrtlsdr. 

This patch fixes my issue by using `LD_LIBRARY_PATH` if available, proceeding with the previously hardcoded search paths, and finally only calls `find_library` if all these attempts to build a `CDLL` have failed.

Cheers!
  