### PR TITLE
Use m2r instead of pypandoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,13 @@ addons:
   apt:
     packages:
       - libusb-1.0-0-dev
-      - pandoc
 before_install:
   - cd tools/travis
   - ./install-librtlsdr.sh
   - cd ../..
   - export LD_LIBRARY_PATH=$HOME/.local:$LD_LIBRARY_PATH
 install:
-  - pip install -U pip setuptools wheel pypandoc
+  - pip install -U pip setuptools wheel m2r
   - pip install -U pytest pytest-xdist pytest-cov coveralls
   - pip install -e .
 script:

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ VERSION = '0.2.7'
 #README = open(os.path.join(HERE, 'README.md')).read()
 
 def convert_readme():
-    import pypandoc
-    rst = pypandoc.convert_file('README.md', 'rst')
+    from m2r import parse_from_file
+    rst = parse_from_file('README.md')
     with open('README.rst', 'w') as f:
         f.write(rst)
     return rst
@@ -67,6 +67,6 @@ setup(
                  'Topic :: Utilities'],
     license='GPLv3',
     keywords='radio librtlsdr rtlsdr sdr',
-    setup_requires=['pypandoc'],
+    setup_requires=['m2r'],
     platforms=['any'],
     packages=find_packages(exclude=['tests*']))


### PR DESCRIPTION
Pypandoc is incompatible with pandoc version 2 and m2r is a lightweight alternative.