### PR TITLE
Numpy optimisations with TCP client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - pip install -e .
 script:
   - sh -c "if [ '$ALLOW_DOC_DEPLOY' = 'true' ]; then travis-sphinx build --source=doc/source --nowarn; fi"
-  - py.test --cov-append --cov-config .coveragerc --cov=rtlsdr
+  - py.test --cov-config .coveragerc --cov=rtlsdr
   - py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --boxed --no-overrides --pyargs tests/no_override*
 after_success:
   - coveralls

--- a/rtlsdr/rtlsdrtcp/base.py
+++ b/rtlsdr/rtlsdrtcp/base.py
@@ -67,9 +67,9 @@ class RtlSdrTcpBase(object):
 
         if has_numpy:
             # use NumPy array
-            iq = np.empty(len(bytes)//2, 'complex')
-            iq.real, iq.imag = bytes[::2], bytes[1::2]
-            iq /= (255/2)
+            data = np.ctypeslib.as_array(bytes)
+            iq = data.astype(np.float64).view(np.complex128)
+            iq /= 127.5
             iq -= (1 + 1j)
         else:
             # use normal list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,21 @@ def pytest_addoption(parser):
     parser.addoption('--no-overrides', action='store_true',
         help='Run tests that do not override (monkeypatch) librtlsdr')
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'no_overrides: mark test to not monkeypatch librtlsdr',
+    )
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--no-overrides'):
+        # '--no-overrides' given, don't skip
+        return
+    skip_no_overrides = pytest.mark.skip(reason='need --no-overrides to run')
+    for item in items:
+        if 'no_overrides' in item.keywords:
+            item.add_marker(skip_no_overrides)
+
 collect_ignore = ['setup.py', 'demo_waterfall.py']
 
 ASYNC_AVAILABLE = sys.version_info.major >= 3

--- a/tests/no_override_client_mode.py
+++ b/tests/no_override_client_mode.py
@@ -1,15 +1,11 @@
 import pytest
 
-no_overrides = pytest.mark.skipif(
-    not pytest.config.getoption('--no-overrides'),
-    reason='need --no-overrides to run'
-)
 
 @pytest.fixture
 def client_mode(monkeypatch):
     monkeypatch.setenv('RTLSDR_CLIENT_MODE', 'true')
 
-@no_overrides
+@pytest.mark.no_overrides
 def test_client_mode(client_mode):
     with pytest.warns(None) as record:
         import rtlsdr

--- a/tests/no_override_dll_loader.py
+++ b/tests/no_override_dll_loader.py
@@ -1,9 +1,5 @@
 import pytest
 
-no_overrides = pytest.mark.skipif(
-    not pytest.config.getoption('--no-overrides'),
-    reason='need --no-overrides to run'
-)
 
 @pytest.fixture(params=[True, False])
 def librtlsdr_missing(request, monkeypatch):
@@ -14,7 +10,7 @@ def librtlsdr_missing(request, monkeypatch):
         monkeypatch.setattr('ctypes.CDLL', FakeCDLL)
     return request.param
 
-@no_overrides
+@pytest.mark.no_overrides
 def test_dll_loader(librtlsdr_missing):
     if librtlsdr_missing:
         with pytest.raises(ImportError):


### PR DESCRIPTION
I noticed that the Numpy optimizations that were made in #88 were not also made in the base TCP file (https://github.com/roger-/pyrtlsdr/blob/190d3ac4308dcf71b0ee3cc791a856852aa96038/rtlsdr/rtlsdrtcp/base.py#L65), apologies if I have missed the reason for this, but I couldn't see why this hadn't been changed.