### PR TITLE
Pytest fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - pip install -e .
 script:
   - sh -c "if [ '$ALLOW_DOC_DEPLOY' = 'true' ]; then travis-sphinx build --source=doc/source --nowarn; fi"
-  - py.test --cov-append --cov-config .coveragerc --cov=rtlsdr
+  - py.test --cov-config .coveragerc --cov=rtlsdr
   - py.test --cov-append --cov-config .coveragerc --cov=rtlsdr --boxed --no-overrides --pyargs tests/no_override*
 after_success:
   - coveralls

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,21 @@ def pytest_addoption(parser):
     parser.addoption('--no-overrides', action='store_true',
         help='Run tests that do not override (monkeypatch) librtlsdr')
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'no_overrides: mark test to not monkeypatch librtlsdr',
+    )
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--no-overrides'):
+        # '--no-overrides' given, don't skip
+        return
+    skip_no_overrides = pytest.mark.skip(reason='need --no-overrides to run')
+    for item in items:
+        if 'no_overrides' in item.keywords:
+            item.add_marker(skip_no_overrides)
+
 collect_ignore = ['setup.py', 'demo_waterfall.py']
 
 ASYNC_AVAILABLE = sys.version_info.major >= 3

--- a/tests/no_override_client_mode.py
+++ b/tests/no_override_client_mode.py
@@ -1,15 +1,11 @@
 import pytest
 
-no_overrides = pytest.mark.skipif(
-    not pytest.config.getoption('--no-overrides'),
-    reason='need --no-overrides to run'
-)
 
 @pytest.fixture
 def client_mode(monkeypatch):
     monkeypatch.setenv('RTLSDR_CLIENT_MODE', 'true')
 
-@no_overrides
+@pytest.mark.no_overrides
 def test_client_mode(client_mode):
     with pytest.warns(None) as record:
         import rtlsdr

--- a/tests/no_override_dll_loader.py
+++ b/tests/no_override_dll_loader.py
@@ -1,9 +1,5 @@
 import pytest
 
-no_overrides = pytest.mark.skipif(
-    not pytest.config.getoption('--no-overrides'),
-    reason='need --no-overrides to run'
-)
 
 @pytest.fixture(params=[True, False])
 def librtlsdr_missing(request, monkeypatch):
@@ -14,7 +10,7 @@ def librtlsdr_missing(request, monkeypatch):
         monkeypatch.setattr('ctypes.CDLL', FakeCDLL)
     return request.param
 
-@no_overrides
+@pytest.mark.no_overrides
 def test_dll_loader(librtlsdr_missing):
     if librtlsdr_missing:
         with pytest.raises(ImportError):


### PR DESCRIPTION
* Update test collection (`mark.skip`) methods for newer py.test (>=5.3.2)
* Only use `--cov-append` after first test invocation
