### PR TITLE
docs: fix simple typo, attatched -> attached

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ loop.run_until_complete(streaming())
 ```
 
 ## rtlsdrtcp
-The `RtlSdrTcpServer` class is meant to be connected physically to an SDR dongle and communicate with an instance of `RtlSdrTcpClient`. The client is intended to function as closely as possible to the base RtlSdr class (as if it had a physical dongle attatched to it).
+The `RtlSdrTcpServer` class is meant to be connected physically to an SDR dongle and communicate with an instance of `RtlSdrTcpClient`. The client is intended to function as closely as possible to the base RtlSdr class (as if it had a physical dongle attached to it).
 
 Both of these classes have the same arguments as the base `RtlSdr` class with the addition of `hostname` and `port`:
 ```python

--- a/rtlsdr/rtlsdrtcp/__init__.py
+++ b/rtlsdr/rtlsdrtcp/__init__.py
@@ -7,7 +7,7 @@ connected physically to an SDR dongle and communicate with an instance of
 
 The client is intended to function as closely as possible to the base
 :class:`~rtlsdr.rtlsdr.RtlSdr` class (as if it had a physical dongle
-attatched to it).
+attached to it).
 
 Both of these classes have the same arguments as the base
 :class:`~rtlsdr.rtlsdr.RtlSdr` class with the addition of ``hostname`` and ``port``.


### PR DESCRIPTION
There is a small typo in README.md, rtlsdr/rtlsdrtcp/__init__.py.

Should read `attached` rather than `attatched`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md