### PR TITLE
Fix typing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,6 @@ All of the code contained here is licensed by the GNU General Public License v3.
 # Credit
 
 Credit to dbasden for his earlier wrapper [python-librtlsdr](https://github.com/dbasden/python-librtlsdr) and all the
-contributers on GitHub.
+contributors on GitHub.
 
 Copyright (C) 2013 by Roger <https://github.com/roger->

--- a/rtlsdr/rtlsdraio.py
+++ b/rtlsdr/rtlsdraio.py
@@ -48,9 +48,9 @@ class AsyncCallbackIter:
 
     Arguments:
         func_start: A callable which should take a single callback that will be
-            passed data. Will be run in a seperate thread in case it blocks.
+            passed data. Will be run in a separate thread in case it blocks.
         func_stop (optional): A callable to stop ``func_start`` from calling the
-            callback. Will be run in a seperate thread in case it blocks.
+            callback. Will be run in a separate thread in case it blocks.
         queue_size (:obj:`int`, optional): The maximum amount of data
             that will be buffered.
         loop (optional): The ``asyncio.event_loop`` to use. If not supplied,

--- a/rtlsdr/rtlsdrtcp/base.py
+++ b/rtlsdr/rtlsdrtcp/base.py
@@ -102,7 +102,7 @@ API_DESCRIPTORS = {
 class MessageBase(object):
     """Base class for messages sent between clients and servers.
 
-    Hanldes serialization/deserialization and communication with
+    Handles serialization/deserialization and communication with
     socket type objects.
 
     Attributes:

--- a/rtlsdr/rtlsdrtcp/client.py
+++ b/rtlsdr/rtlsdrtcp/client.py
@@ -62,7 +62,7 @@ class RtlSdrTcpClient(RtlSdrTcpBase):
             resp_data = resp.data
         elif isinstance(resp, AckMessage):
             if not resp.header.get('ok'):
-                raise CommunicationError('ACK message recieved as "NAK"')
+                raise CommunicationError('ACK message received as "NAK"')
             resp_data = None
         self._close_socket()
         return resp_data

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -87,7 +87,7 @@ def check_close(num_digits, *args):
 
 def generic_test(sdr, test_async=True, test_exceptions=True, use_numpy=True):
     """Functionality checks common to all tests
-    Instanciates the given subclass of :class:`rtlsdr.RtlSdr`,
+    Instantiates the given subclass of :class:`rtlsdr.RtlSdr`,
     checks get/set methods for sample_rate, center_freq and gain,
     then reads 1024 samples.
 


### PR DESCRIPTION
This PR fixes some small typing errors found with `codespell`